### PR TITLE
account for divide by zero in stats averaging

### DIFF
--- a/lib/tabs/metrics/counter/stats.rb
+++ b/lib/tabs/metrics/counter/stats.rb
@@ -33,7 +33,9 @@ module Tabs
         end
 
         def avg
-          round_float(self.total.to_f / values.size.to_f)
+          return 0 if values.size.zero?
+
+          round_float(total.to_f / values.size.to_f)
         end
 
         def each(&block)

--- a/lib/tabs/metrics/value/stats.rb
+++ b/lib/tabs/metrics/value/stats.rb
@@ -37,7 +37,9 @@ module Tabs
         end
 
         def avg
-          round_float(self.sum.to_f / self.count.to_f)
+          return 0 if count.zero?
+
+          round_float(sum.to_f / count.to_f)
         end
 
         def each(&block)

--- a/spec/lib/tabs/metrics/counter/stats_spec.rb
+++ b/spec/lib/tabs/metrics/counter/stats_spec.rb
@@ -34,4 +34,9 @@ describe Tabs::Metrics::Counter::Stats do
     expect(stats.avg).to eq 86.33
   end
 
+  it "avg returns 0 if values empty" do
+    stats = Tabs::Metrics::Counter::Stats.new(period, resolution, [])
+    expect(stats.avg).to be_zero
+  end
+
 end

--- a/spec/lib/tabs/metrics/value/stats_spec.rb
+++ b/spec/lib/tabs/metrics/value/stats_spec.rb
@@ -38,4 +38,9 @@ describe Tabs::Metrics::Value::Stats do
     expect(stats.avg).to eq 16.76
   end
 
+  it "avg returns 0 if set is empty" do
+    stats = Tabs::Metrics::Value::Stats.new(period, resolution, [])
+    expect(stats.avg).to be_zero
+  end
+
 end

--- a/spec/lib/tabs/metrics/value_spec.rb
+++ b/spec/lib/tabs/metrics/value_spec.rb
@@ -95,7 +95,6 @@ describe Tabs::Metrics::Value do
       expect(stats).to include({ "timestamp" => (now + 3.years), "count"=>1, "min"=>10, "max"=>10, "sum"=>10, "avg"=>10})
       expect(stats).to include({ "timestamp" => (now + 6.years), "count"=>2, "min"=>15, "max"=>20, "sum"=>35, "avg"=>17})
     end
-
   end
 
   describe ".drop!" do


### PR DESCRIPTION
Previously returned NaN if size array was empty.
