### PR TITLE
Fix race condition

### DIFF
--- a/spec/lib/tabs_spec.rb
+++ b/spec/lib/tabs_spec.rb
@@ -33,6 +33,19 @@ describe Tabs do
 
   end
 
+  describe ".get_or_create_metric" do
+    it "creates the metric if it does not exist" do
+      expect(Tabs).to receive(:create_metric).with("foo","counter")
+      Tabs.get_or_create_metric("foo","counter")
+    end
+
+    it "returns the existing metric if metric exists" do
+      Tabs.create_metric("foo","counter")
+      expect(Tabs).to receive(:get_metric).with("foo","counter")
+      Tabs.get_or_create_metric("foo","counter")
+    end
+  end
+
   describe ".counter_total" do
 
     it "returns the total for a counter metric" do
@@ -54,9 +67,13 @@ describe Tabs do
 
     it "returns the expected metric object" do
       Tabs.create_metric("foo", "counter")
-      expect(Tabs.get_metric("foo")).to be_a_kind_of(Tabs::Metrics::Counter)
+      expect(Tabs.get_metric("foo","counter")).to be_a_kind_of(Tabs::Metrics::Counter)
     end
 
+    it "raises an MetricTypeMismatchError when metric types do not match" do
+      Tabs.create_metric("foo","counter")
+      lambda { Tabs.get_metric("foo","task") }.should raise_error Tabs::MetricTypeMismatchError
+    end
   end
 
   describe ".list_metrics" do

--- a/tabs.gemspec
+++ b/tabs.gemspec
@@ -32,7 +32,7 @@ EOS
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-nav"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec"
+  gem.add_development_dependency "rspec", "~> 2"
   gem.add_development_dependency "timecop"
 
 end


### PR DESCRIPTION
There is a race condition in the following functions
- Tabs#increment_counter
- Tabs#record_value
- Tabs#start_task

All function check if the requested metric exist. If not they try to create it, but in the mean time it is possible that an other thread has already created it. This results in the following code to fail repeatedly with a `Tabs::DuplicateMetricError`

``` ruby
5.times.map do 
  Thread.new do
    Tabs.increment_counter("test_counter")
  end
end.each(&:join)
```

Adding a get_or_create_metric function using a shared mutex prevents this race condition.
