### PR TITLE
Relax Redis dependency version requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ rvm:
   - 2.0.0
 services:
   - redis-server
+sudo: false

--- a/spec/lib/tabs/metrics/counter_spec.rb
+++ b/spec/lib/tabs/metrics/counter_spec.rb
@@ -135,7 +135,7 @@ describe Tabs::Metrics::Counter do
 
     before do
       3.times { metric.increment }
-      expect(exists("stat:counter:foo:total")).to be_true
+      expect(exists("stat:counter:foo:total")).to be_truthy
       @count_keys = (Tabs::Resolution.all.map do |res|
         smembers("stat:counter:foo:keys:#{res}")
       end).flatten
@@ -143,18 +143,18 @@ describe Tabs::Metrics::Counter do
     end
 
     it "deletes the counter total key" do
-      expect(exists("stat:counter:foo:total")).to be_false
+      expect(exists("stat:counter:foo:total")).to be_falsey
     end
 
     it "deletes all resolution count keys" do
       @count_keys.each do |key|
-        expect(exists(key)).to be_false
+        expect(exists(key)).to be_falsey
       end
     end
 
     it "deletes all resolution key collection keys" do
       Tabs::Resolution.all.each do |res|
-        expect(exists("stat:counter:foo:keys:#{res}")).to be_false
+        expect(exists("stat:counter:foo:keys:#{res}")).to be_falsey
       end
     end
 

--- a/spec/lib/tabs/metrics/task_spec.rb
+++ b/spec/lib/tabs/metrics/task_spec.rb
@@ -14,14 +14,14 @@ describe Tabs::Metrics::Task do
     let(:time) { Time.now }
 
     it "calls start on the given token" do
-      Tabs::Metrics::Task::Token.should_receive(:new).with(token_1, "foo").and_return(token)
-      token.should_receive(:start)
+      expect(Tabs::Metrics::Task::Token).to receive(:new).with(token_1, "foo").and_return(token)
+      expect(token).to receive(:start)
       metric.start(token_1)
     end
 
     it "passes through the specified timestamp" do
-      Tabs::Metrics::Task::Token.stub(new: token)
-      token.should_receive(:start).with(time)
+      allow(Tabs::Metrics::Task::Token).to receive(:new).and_return(token)
+      expect(token).to receive(:start).with(time)
       metric.start(token_1, time)
     end
 
@@ -33,19 +33,19 @@ describe Tabs::Metrics::Task do
     let(:time) { Time.now }
 
     it "calls complete on the given token" do
-      Tabs::Metrics::Task::Token.should_receive(:new).with(token_1, "foo").and_return(token)
-      token.should_receive(:complete)
+      expect(Tabs::Metrics::Task::Token).to receive(:new).with(token_1, "foo").and_return(token)
+      expect(token).to receive(:complete)
       metric.complete(token_1)
     end
 
     it "passes through the specified timestamp" do
-      Tabs::Metrics::Task::Token.stub(new: token)
-      token.should_receive(:complete).with(time)
+      allow(Tabs::Metrics::Task::Token).to receive(:new).and_return(token)
+      expect(token).to receive(:complete).with(time)
       metric.complete(token_1, time)
     end
 
     it "raises an UnstartedTaskMetricError if the metric has not yet been started" do
-      lambda { metric.complete("foobar") }.should raise_error(Tabs::Metrics::Task::UnstartedTaskMetricError)
+      expect { metric.complete("foobar") }.to raise_error(Tabs::Metrics::Task::UnstartedTaskMetricError)
     end
 
   end

--- a/spec/lib/tabs/metrics/value_spec.rb
+++ b/spec/lib/tabs/metrics/value_spec.rb
@@ -113,13 +113,13 @@ describe Tabs::Metrics::Value do
 
     it "deletes all resolution count keys" do
       @count_keys.each do |key|
-        expect(exists(key)).to be_false
+        expect(exists(key)).to be_falsey
       end
     end
 
     it "deletes all resolution key collection keys" do
       Tabs::Resolution.all.each do |res|
-        expect(exists("stat:value:foo:keys:#{res}")).to be_false
+        expect(exists("stat:value:foo:keys:#{res}")).to be_falsey
       end
     end
 

--- a/spec/lib/tabs/resolution_spec.rb
+++ b/spec/lib/tabs/resolution_spec.rb
@@ -23,7 +23,7 @@ describe Tabs::Resolution do
       end
 
       it "raises an error when method not implemented" do
-        expect{BadlyFormedResolution.normalize}.to raise_error
+        expect{BadlyFormedResolution.normalize}.to raise_error(RuntimeError)
       end
 
       it "disregards already registered resolutions" do

--- a/spec/lib/tabs/resolutionable_spec.rb
+++ b/spec/lib/tabs/resolutionable_spec.rb
@@ -20,7 +20,7 @@ describe Tabs::Resolutionable do
 
     ["serialize", "deserialize", "from_seconds", "add", "normalize"].each do |method|
       it "are raised when the #{method} method is not implemented" do
-        expect { TestResolution.send(method) }.to raise_error
+        expect { TestResolution.send(method) }.to raise_error(RuntimeError)
       end
     end
 

--- a/spec/lib/tabs/storage_spec.rb
+++ b/spec/lib/tabs/storage_spec.rb
@@ -27,8 +27,8 @@ describe Tabs::Storage do
     let(:stubbed_redis) { double("redis").as_null_object }
 
     before do
-      subject.stub(redis: stubbed_redis)
-      subject.should_receive(:tabs_key).at_least(:once).and_call_original
+      allow(subject).to receive(:redis).and_return(stubbed_redis)
+      expect(subject).to receive(:tabs_key).at_least(:once).and_call_original
     end
 
     it "#exists calls exists with the expected key" do
@@ -67,7 +67,7 @@ describe Tabs::Storage do
     end
 
     it "#del_by_prefix" do
-      stubbed_redis.stub(keys: ["foo:a", "foo:b"])
+      allow(stubbed_redis).to receive(:keys).and_return(["foo:a", "foo:b"])
       subject.del_by_prefix("foo")
       expect(stubbed_redis).to have_received(:del).with("foo:a", "foo:b")
     end
@@ -93,7 +93,7 @@ describe Tabs::Storage do
     end
 
     it "#smembers_all" do
-      stubbed_redis.should_receive(:pipelined).and_yield
+      expect(stubbed_redis).to receive(:pipelined).and_yield
       subject.smembers_all("foo", "bar")
       expect(stubbed_redis).to have_received(:smembers).with("tabs:foo")
       expect(stubbed_redis).to have_received(:smembers).with("tabs:bar")

--- a/spec/lib/tabs_spec.rb
+++ b/spec/lib/tabs_spec.rb
@@ -73,11 +73,11 @@ describe Tabs do
 
     it "returns true if the metric exists" do
       Tabs.create_metric("foo", "counter")
-      expect(Tabs.metric_exists?("foo")).to be_true
+      expect(Tabs.metric_exists?("foo")).to be_truthy
     end
 
     it "returns false if the metric does not exist" do
-      expect(Tabs.metric_exists?("foo")).to be_false
+      expect(Tabs.metric_exists?("foo")).to be_falsey
     end
 
   end
@@ -95,7 +95,7 @@ describe Tabs do
 
     it "results in metric_exists? returning false" do
       Tabs.drop_metric!("foo")
-      expect(Tabs.metric_exists?("foo")).to be_false
+      expect(Tabs.metric_exists?("foo")).to be_falsey
     end
 
     it "calls drop! on the metric" do
@@ -113,8 +113,8 @@ describe Tabs do
       Tabs.create_metric("foo", "counter")
       Tabs.create_metric("bar", "value")
       Tabs.drop_all_metrics!
-      expect(Tabs.metric_exists?("foo")).to be_false
-      expect(Tabs.metric_exists?("bar")).to be_false
+      expect(Tabs.metric_exists?("foo")).to be_falsey
+      expect(Tabs.metric_exists?("bar")).to be_falsey
     end
 
   end
@@ -127,9 +127,9 @@ describe Tabs do
     end
 
     it "creates the metric if it doesn't exist" do
-      expect(Tabs.metric_exists?("foo")).to be_false
+      expect(Tabs.metric_exists?("foo")).to be_falsey
       expect { Tabs.increment_counter("foo") }.to_not raise_error
-      expect(Tabs.metric_exists?("foo")).to be_true
+      expect(Tabs.metric_exists?("foo")).to be_truthy
     end
 
     it "calls increment on the metric" do
@@ -144,9 +144,9 @@ describe Tabs do
   describe ".record_value" do
 
     it "creates the metric if it doesn't exist" do
-      expect(Tabs.metric_exists?("foo")).to be_false
+      expect(Tabs.metric_exists?("foo")).to be_falsey
       expect { Tabs.record_value("foo", 38) }.to_not raise_error
-      expect(Tabs.metric_exists?("foo")).to be_true
+      expect(Tabs.metric_exists?("foo")).to be_truthy
     end
 
     it "raises a Tabs::MetricTypeMismatchError if the metric is the wrong type" do
@@ -216,7 +216,7 @@ describe Tabs do
       metric.record(42, now)
       Tabs.drop_resolution_for_metric!("baz", :minute)
       minute_key = Tabs::Metrics::Value.new("baz").storage_key(:minute, now)
-      expect(Tabs::Storage.exists(minute_key)).to be_false
+      expect(Tabs::Storage.exists(minute_key)).to be_falsey
     end
   end
 

--- a/spec/lib/tabs_spec.rb
+++ b/spec/lib/tabs_spec.rb
@@ -6,12 +6,12 @@ describe Tabs do
   describe ".create_metric" do
 
     it "raises an error if the type is invalid" do
-      lambda { Tabs.create_metric("foo", "foobar") }.should raise_error(Tabs::UnknownTypeError)
+      expect { Tabs.create_metric("foo", "foobar") }.to raise_error(Tabs::UnknownTypeError)
     end
 
     it "raises an error if the metric already exists" do
       Tabs.create_metric("foo", "counter")
-      lambda { Tabs.create_metric("foo", "counter") }.should raise_error(Tabs::DuplicateMetricError)
+      expect { Tabs.create_metric("foo", "counter") }.to raise_error(Tabs::DuplicateMetricError)
     end
 
     it "returns a Counter metric if 'counter' was the specified type" do
@@ -100,8 +100,8 @@ describe Tabs do
 
     it "calls drop! on the metric" do
       metric = double(:metric)
-      Tabs.stub(get_metric: metric)
-      metric.should_receive(:drop!)
+      allow(Tabs).to receive(:get_metric).and_return(metric)
+      expect(metric).to receive(:drop!)
       Tabs.drop_metric!("foo")
     end
 
@@ -123,19 +123,19 @@ describe Tabs do
 
     it "raises a Tabs::MetricTypeMismatchError if the metric is the wrong type" do
       Tabs.create_metric("foo", "value")
-      lambda { Tabs.increment_counter("foo") }.should raise_error(Tabs::MetricTypeMismatchError)
+      expect { Tabs.increment_counter("foo") }.to raise_error(Tabs::MetricTypeMismatchError)
     end
 
     it "creates the metric if it doesn't exist" do
       expect(Tabs.metric_exists?("foo")).to be_false
-      lambda { Tabs.increment_counter("foo") }.should_not raise_error
+      expect { Tabs.increment_counter("foo") }.to_not raise_error
       expect(Tabs.metric_exists?("foo")).to be_true
     end
 
     it "calls increment on the metric" do
       metric = Tabs.create_metric("foo", "counter")
-      Tabs.stub(get_metric: metric)
-      metric.should_receive(:increment)
+      allow(Tabs).to receive(:get_metric).and_return(metric)
+      expect(metric).to receive(:increment)
       Tabs.increment_counter("foo")
     end
 
@@ -145,20 +145,20 @@ describe Tabs do
 
     it "creates the metric if it doesn't exist" do
       expect(Tabs.metric_exists?("foo")).to be_false
-      lambda { Tabs.record_value("foo", 38) }.should_not raise_error
+      expect { Tabs.record_value("foo", 38) }.to_not raise_error
       expect(Tabs.metric_exists?("foo")).to be_true
     end
 
     it "raises a Tabs::MetricTypeMismatchError if the metric is the wrong type" do
       Tabs.create_metric("foo", "counter")
-      lambda { Tabs.record_value("foo", 27) }.should raise_error(Tabs::MetricTypeMismatchError)
+      expect { Tabs.record_value("foo", 27) }.to raise_error(Tabs::MetricTypeMismatchError)
     end
 
     it "calls record on the metric" do
       Timecop.freeze(Time.now.utc)
       metric = Tabs.create_metric("foo", "value")
-      Tabs.stub(get_metric: metric)
-      metric.should_receive(:record).with(42, Time.now.utc)
+      allow(Tabs).to receive(:get_metric).and_return(metric)
+      expect(metric).to receive(:record).with(42, Time.now.utc)
       Tabs.record_value("foo", 42)
     end
 
@@ -206,7 +206,7 @@ describe Tabs do
 
     it "does not allow you to call drop_by_resolution if task metric" do
       metric = Tabs.create_metric("baz", "task")
-      metric.should_not_receive(:drop_by_resolution!)
+      expect(metric).to_not receive(:drop_by_resolution!)
       Tabs.drop_resolution_for_metric!("baz", :minute)
     end
 

--- a/tabs.gemspec
+++ b/tabs.gemspec
@@ -27,7 +27,7 @@ within major point releases.
 EOS
 
   gem.add_dependency "activesupport", ">= 3.2"
-  gem.add_dependency "redis", "~> 3.0"
+  gem.add_dependency "redis", ">= 3.0.0"
 
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-nav"

--- a/tabs.gemspec
+++ b/tabs.gemspec
@@ -27,7 +27,7 @@ within major point releases.
 EOS
 
   gem.add_dependency "activesupport", ">= 3.2"
-  gem.add_dependency "redis", "~> 3.0.0"
+  gem.add_dependency "redis", "~> 3.0"
 
   gem.add_development_dependency "pry"
   gem.add_development_dependency "pry-nav"


### PR DESCRIPTION
Ran into issues in a project that included both `sidekiq` and `tabs` when trying to upgrade `sidekiq` to v3.5.0, which [depends on](https://github.com/mperham/sidekiq/blob/v3.5.0/sidekiq.gemspec#L18) the `redis` gem being `'~> 3.2', '>= 3.2.1'`. 

I couldn't find any reason tabs needed to be limited to only the `3.0.x` versions of the gem, so relaxing the requirement seemed to make sense. 

Thanks for your work on `tabs` @thegrubbsian! Let me know if you'd like to see this handled a different way or if you have any questions. Thanks!
